### PR TITLE
Validate Gazebo Files in CI

### DIFF
--- a/.github/workflows/sdf.yml
+++ b/.github/workflows/sdf.yml
@@ -1,0 +1,34 @@
+name: SDF Validation
+
+on:
+  push:
+    paths:
+    - '**.sdf'
+  pull_request:
+    paths:
+    - '**.sdf'
+
+  workflow_dispatch:
+
+jobs:
+  validate:
+
+    name: Validate SDF files
+
+    runs-on: ubuntu-latest
+
+    env:
+      SCHEMA_URL: http://sdformat.org/schemas/root.xsd
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Required Packages
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+      - name: Setup xmllint annotations
+        uses: korelstar/xmllint-problem-matcher@v1
+
+      - name: Lint SDF files
+        # ripped from https://github.com/korelstar/xmllint-problem-matcher/blob/26cc4130cb560d39ef1320273f1662ba9182d05f/.github/workflows/lint.yml#L18
+        run: fd '.sdf' "$GITHUB_WORKSPACE" -tf -X xmllint --schema "$SCHEMA_URL" --noout
+
+  # TODO: check formatting of SDF files

--- a/.github/workflows/sdf.yml
+++ b/.github/workflows/sdf.yml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
     - '**.sdf'
+    - '**.world'
   pull_request:
     paths:
     - '**.sdf'
+    - '**.world'
 
   workflow_dispatch:
 
@@ -23,12 +25,16 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Required Packages
-        run: sudo apt-get install --no-install-recommends -y libxml2-utils
+        run: sudo apt-get install --no-install-recommends -y libxml2-utils fd-find
+      - name: Verify Installations
+        run: |
+          xmllint --version
+          fd --version
       - name: Setup xmllint annotations
         uses: korelstar/xmllint-problem-matcher@v1
 
       - name: Lint SDF files
-        # ripped from https://github.com/korelstar/xmllint-problem-matcher/blob/26cc4130cb560d39ef1320273f1662ba9182d05f/.github/workflows/lint.yml#L18
-        run: fd '.sdf' "$GITHUB_WORKSPACE" -tf -X xmllint --schema "$SCHEMA_URL" --noout
+        working-directory: ${{ env.GITHUB_WORKSPACE }}
+        run: fd -tf -e 'sdf' -e 'world' -X xmllint --schema "$SCHEMA_URL" --noout --load-trace
 
   # TODO: check formatting of SDF files

--- a/.github/workflows/sdf.yml
+++ b/.github/workflows/sdf.yml
@@ -29,12 +29,12 @@ jobs:
       - name: Verify Installations
         run: |
           xmllint --version
-          fd --version
+          fdfind --version
       - name: Setup xmllint annotations
         uses: korelstar/xmllint-problem-matcher@v1
 
       - name: Lint SDF files
         working-directory: ${{ env.GITHUB_WORKSPACE }}
-        run: fd -tf -e 'sdf' -e 'world' -X xmllint --schema "$SCHEMA_URL" --noout --load-trace
+        run: fdfind -tf -e 'sdf' -e 'world' -X xmllint --schema "$SCHEMA_URL" --noout --load-trace
 
   # TODO: check formatting of SDF files


### PR DESCRIPTION
Proposes using GitHub actions CI to passively validate `.sdf` and `.world` files using SDFormat's root WXS schema. This can catch errors in Gazebo simulation models committed to the repository. I have verified that it works as expected in a separate branch; however, the ran caught errors in the Gazebo Model Database, indicating there might be a need to include more schemas or use a custom schema (due to outdated SDFormat resources).